### PR TITLE
Added RandomFirstLetter casing type

### DIFF
--- a/Diceware.cs
+++ b/Diceware.cs
@@ -156,6 +156,13 @@ namespace KeePassDiceware
 						string first = words[scan][0].ToString().ToUpperInvariant();
 						words[scan] = $"{first}{words[scan].Substring(1)}";
 						break;
+					case WordCasingType.RandomFirstLetter:
+						if (random.CoinToss())
+						{
+							string firstLetter = words[scan][0].ToString().ToUpperInvariant();
+							words[scan] = $"{firstLetter}{words[scan].Substring(1)}";
+						}
+						break;
 					case WordCasingType.Random:
 						char[] randomized = (from c in words[scan].ToCharArray()
 											 select (random.CoinToss()

--- a/WordCasingType.cs
+++ b/WordCasingType.cs
@@ -31,5 +31,7 @@ namespace KeePassDiceware
 		Random,
 		[Description("Random Whole Words")]
 		WholeWord,
+		[Description("Random First Letters")]
+		RandomFirstLetter,
 	};
 }


### PR DESCRIPTION
Love the plugin! I wanted to add a casing type that resulted in the first letters of words being capitalized at random, so like TitleCase but applied randomly to each word based on a coin toss. I think it adds a nice bit of unpredictability to the generated passwords.

**Screenshots**

![image](https://github.com/user-attachments/assets/84fbcf94-ce76-4d8e-ac66-7a0ad0183a76)

![image](https://github.com/user-attachments/assets/bc8689c2-d03c-4c73-819e-95d0ae0fe9ba)

Works great! Let me know what you think, glad for the opportunity to contribute.
