### PR TITLE
Randomize order of salt characters

### DIFF
--- a/Diceware.cs
+++ b/Diceware.cs
@@ -345,7 +345,7 @@ namespace KeePassDiceware
 				result.Append(chars);
 			}
 
-			return result?.ToString() ?? string.Empty;
+			return result?.ToString().Shuffle(random) ?? string.Empty;
 		}
 
 		public static IEnumerable<string> GetWordList(List<WordList> lists)

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -1,5 +1,6 @@
 
 using System;
+using System.Linq;
 
 using KeePassLib.Cryptography;
 
@@ -105,5 +106,24 @@ namespace KeePassDiceware
 		/// TRUE / FALSE with equal probabilities.
 		/// </returns>
 		public static bool CoinToss(this CryptoRandomStream random) => (random.GetRandomBytes(1)[0] & 1) == 0;
+
+		/// <summary>
+		/// Shuffles the order of characters in input string <paramref name="str"/>.
+		/// </summary>
+		/// <param name="str">String to shuffle.</param>
+		/// <returns>
+		/// A new string with the characters in a random order.
+		/// </returns>
+		public static string Shuffle(this string str, CryptoRandomStream random)
+		{
+			if (string.IsNullOrEmpty(str) || str.Length <= 1)
+			{
+				return str;
+			}
+
+			string result = new(str.ToCharArray().OrderBy(s => random.AtMost(ulong.MaxValue)).ToArray());
+
+			return result;
+		}
 	}
 }


### PR DESCRIPTION
This resolves #41. Added an extension method to randomize the order of strings, and used the method in the GenerateSalt method to return a salt with the character order randomized. When the salt is 1 character long or empty, it has no effect.

## Screenshots 

![image](https://github.com/user-attachments/assets/cc7ca510-ee48-4fe9-a41a-fdac829011a7)

![image](https://github.com/user-attachments/assets/1b102125-afd6-46fe-a510-b1b5c078617c)

