### PR TITLE
Add new salt position options

### DIFF
--- a/Diceware.cs
+++ b/Diceware.cs
@@ -294,6 +294,14 @@ namespace KeePassDiceware
 
 					words[targetIndex] = $"{words[targetIndex]}{separator}{singleSalt}";
 					break;
+				case SaltType.SuffixToRandomWord:
+					int suffixToIndex = random.AtMost(words.Length - 1);
+					words[suffixToIndex] = $"{words[suffixToIndex]}{singleSalt}";
+					break;
+				case SaltType.PrefixToRandomWord:
+					int prefixToIndex = random.AtMost(words.Length - 1);
+					words[prefixToIndex] = $"{singleSalt}{words[prefixToIndex]}";
+					break;
 				default:
 					throw new ArgumentOutOfRangeException(nameof(salt));
 			}

--- a/Diceware.cs
+++ b/Diceware.cs
@@ -302,6 +302,17 @@ namespace KeePassDiceware
 					int prefixToIndex = random.AtMost(words.Length - 1);
 					words[prefixToIndex] = $"{singleSalt}{words[prefixToIndex]}";
 					break;
+				case SaltType.AsSeparateWordOnce:
+					int insertBefore = random.AtMost(words.Length);
+					if (insertBefore != words.Length)
+					{
+						words[insertBefore] = $"{singleSalt}{separator}{words[insertBefore]}";
+					}
+					else // There is no word with index insertBefore, we need to append it
+					{
+						words[insertBefore - 1] = $"{words[insertBefore - 1]}{separator}{singleSalt}";
+					}
+					break;
 				default:
 					throw new ArgumentOutOfRangeException(nameof(salt));
 			}

--- a/SaltType.cs
+++ b/SaltType.cs
@@ -40,5 +40,7 @@ namespace KeePassDiceware
 		PrefixToRandomWord,
 		[Description("Appended to the end of a random word")]
 		SuffixToRandomWord,
+		[Description("Insert as a separate word at a random position, once")]
+		AsSeparateWordOnce,
 	}
 }

--- a/SaltType.cs
+++ b/SaltType.cs
@@ -36,5 +36,9 @@ namespace KeePassDiceware
 		BetweenOne,
 		[Description("Between each word")]
 		BetweenEach,
+		[Description("Prepend to the beginning of a random word")]
+		PrefixToRandomWord,
+		[Description("Appended to the end of a random word")]
+		SuffixToRandomWord,
 	}
 }


### PR DESCRIPTION
Hello,
hope you are doing well. I finally had a bit of free time again.

This PR should closes #36 and #38, where there are requests for a few different salt position options.

The new options allow the salt to be prefixed/affixed to a word without a separator, and inserted "as another word" (between words, or as first/last word) while using appropriate separators.


### The new option in salt position:
![image](https://github.com/user-attachments/assets/a88eeaaf-605d-42ee-af5e-4e58a2f3b29a)

### Example generated passwords:
(numbers represent salt)
(`~` is a separator)
```
Prepend to the beginning of a random word:
romp~4209stoic~toni~worth~avery
hole~ducat~coin~galaxy~0781lot

Appended to the end of a random word:
beat6802~turin~pry~puny~swear
boost~inapt1671~dc~hhh~wast

Insert as a separate word at a random position, once:
2454~moor~fling~bum~bg~seemed
typic~knelt~darry~feud~5447~boss
```


### Notes:
- I am not exactly happy with the implementation of `AsSeparateWordOnce`. I would prefer to insert it as another word into the array. But with the current setup, it is more trouble than it is worth. So I think this works just fine.
- I am a bit worried about how many salt position options are there now. It might soon become too confusing. Let me know if you want me to only add some of them.