### PR TITLE
Add Random Whole Word word casing option

### DIFF
--- a/WordCasingType.cs
+++ b/WordCasingType.cs
@@ -33,6 +33,8 @@ namespace KeePassDiceware
 		[Description("Title Case Random")]
 		TitleCaseRandom,
 		Random,
+		[Description("Random Whole Word")]
+		WholeWordOneRandom,
 		[Description("Random Whole Words")]
 		WholeWord,
 	};


### PR DESCRIPTION
Hello,
this PR closes #39.

There was a request to add a new word casing option that would convert a ONE word to upper case.
I believe this is a reasonable addition, especially to satisfy the "at least one upper case letter" requirement.

### The new option in word casings:
![image](https://github.com/user-attachments/assets/afbda0c2-9be5-48bd-888f-1f8c027b8c4c)

### Example generated passwords:
(`~` is a separator)
```
mixes~mowed~tempt~fats~ANNE
ocr~PAGAN~obit~plank~berra
BLEAT~bog~dressy~ma~among
```

### Notes:
- The new option is implemented on lines 213-216 in Diceware.cs.
- I reorganized the `ApplyWordCasing` function to make it a bit simpler (at least for me). Where the `ApplyWordCasing` function handles one off changes, and a second function `ApplyWordCasingAcrossMultipleWords` (that is called from the main `ApplyWordCasing`) handles changes where we need to iterate over every word.
